### PR TITLE
Pinfo first implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _*
 *.swo
 *.*~
 *~
+*.log
 .erlang.cookie
 .DS_Store
 ebin

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ elixir:
 otp_release:
   - 18.1
   - 18.0
+  - 17.5
+  - 17.4
+  - 17.3
+  - 17.0
 install: "true"
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ elixir:
 otp_release:
   - 18.1
   - 18.0
+  - 17.5
+  - 17.4
+  - 17.3
+  - 17.0
 install: "true"
 branches:
   only:
     - master
     - develop
-script: "make test dialyzer"
+script: "make test"
 cache:
   directories:
   - _plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ branches:
     - master
     - develop
 script: "make test dialyzer"
+after_success:
+  - mix do compile, coveralls.travis
+after_script:
+  - MIX_ENV=docs mix deps.get
+  - MIX_ENV=docs mix inch.report
 cache:
   directories:
   - _plt
@@ -22,4 +27,3 @@ cache:
 notifications:
   email:
     - priestjim@gmail.com
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ branches:
     - master
     - develop
 
+before_script:
+  - mix local.hex --force
+  - mix deps.get --only test
+
 script: "make test"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script: "make test dialyzer"
 cache:
   directories:
   - _plt
+  - $HOME/.mix/archives
 notifications:
   email:
     - priestjim@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ branches:
     - master
     - develop
 
-before_script:
-  - mix local.hex --force
-  - mix deps.get --only test
-
 script: "make test"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install: "true"
 branches:
   only:
     - master
+    - develop
 script: "make test dialyzer"
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ otp_release:
   - 18.0
   - 17.5
   - 17.4
-  - 17.3
-  - 17.0
+
 install: "true"
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ branches:
 script: "make test dialyzer"
 after_success:
   - mix do compile, coveralls.travis
-after_script:
-  - MIX_ENV=docs mix deps.get
-  - MIX_ENV=docs mix inch.report
 cache:
   directories:
   - _plt

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ PLT_FILE := _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt
 # =============================================================================
 
 all:
+	@MIX_ENV=dev $(MIX) deps.get && $(MIX) local.hex --force 
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,9 @@ $(PLT_FILE):
 ifeq ($(DIALYXIR),)
 	@echo "Dialyxir not found. Installing from source"
 	@git clone $(DIALYXIR_URL) dialyxir && \
-	  cd dialyxir && mix archive.build && mix archive.install && \
+	  cd dialyxir && \
+	  mix archive.build && \
+	  mix archive.install --force && \
 	  rm -fr dialyxir
 endif
 	@mkdir -p _plt

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ endif
 # =============================================================================
 ERL = $(shell which erl 2> /dev/null)
 ELIXIR = $(shell which elixir 2> /dev/null)
+MIX = $(shell which mix 2> /dev/null)
 IEX = $(shell which iex 2> /dev/null)
 DIALYXIR = $(shell mix help 2> /dev/null | grep dialyzer.plt)
 DIALYXIR_URL = https://github.com/jeremyjh/dialyxir.git
@@ -52,6 +53,9 @@ ifeq ($(IEX),)
 	$(error "IEx is not available on this system")
 endif
 
+ifeq ($(IEX),)
+	$(error "IEx is not available on this system")
+endif
 # Dialyzer
 ERLANG_VERSION := $(shell $(ERL) -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().' -noshell)
 ELIXIR_VERSION := $(shell $(ELIXIR) -v | cut -d\  -f2 | sed -e 's/-dev//')
@@ -65,6 +69,7 @@ all:
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all
+	@yes | $(MIX) local.rebar && yes | $(MIX) local.hex 
 	@MIX_ENV=test $(ELIXIR) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix t
 
 dialyzer: _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt all

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 .PHONY: all test dialyzer xref spec dist
 
 # Run targets
-.PHONY: shell
+.PHONY: shell shell-slave
 
 # Misc targets
 .PHONY: clean testclean distclean tags rebar
@@ -64,7 +64,7 @@ PLT_FILE := _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt
 all:
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
-test: epmd
+test: epmd all
 	@MIX_ENV=test $(ELIXIR) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix t
 
 dialyzer: _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt all
@@ -88,6 +88,9 @@ endif
 
 shell: epmd
 	@MIX_ENV=dev $(IEX) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix
+
+shell-slave: epmd
+	@MIX_ENV=dev $(IEX) --name exrpc_slave@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix
 
 # =============================================================================
 # Misc targets

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ all:
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all
+	@MIX_ENV=test $(MIX) deps.get && $(MIX) local.hex --force 
 	@MIX_ENV=test $(ELIXIR) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix t
 
 dialyzer: _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt all

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ all:
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all
-	@yes | $(MIX) local.rebar && yes | $(MIX) local.hex 
 	@MIX_ENV=test $(ELIXIR) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix t
 
 dialyzer: _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt all

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![Build Status](https://travis-ci.org/priestjim/exrpc.svg)](https://travis-ci.org/priestjim/exrpc)
 
++master: [![Coverage Status](https://coveralls.io/repos/priestjim/exrpc/badge.svg?branch=master&service=github)](https://coveralls.io/github/priestjim/exrpc?branch=master)
++develop: [![Coverage Status](https://coveralls.io/repos/priestjim/exrpc/badge.svg?branch=develop&service=github)](https://coveralls.io/github/priestjim/exrpc?branch=develop)
+
 # ExRPC
 
 `ExRPC` is an out-of band messaging library that uses TCP ports to

--- a/config/vm.args
+++ b/config/vm.args
@@ -5,6 +5,7 @@
 ## Enable kernel poll and a few async threads
 +K true
 +A 4
++a 8192
 
 ## Enable unicode
 +pc unicode

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -104,9 +104,12 @@ defmodule ExRPC do
 
   @spec pinfo(node, pid, atom) :: {:badtcp | :badrpc, any} | list
   def pinfo(node, pid, a \\ nil)
-  when is_atom(node) and is_atom(a)
+  when is_atom(node) and is_pid(pid) and is_atom(a)
   do
-    ExRPC.Client.call(node, Process, :info, [pid, a])
-  end
+    cond a
+        nil -> ExRPC.Client.call(node, Process, :info, [pid, []])
+        _ -> ExRPC.Client.call(node, Process, :info, [pid, a])
+    end 
+ end
 
 end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -102,11 +102,11 @@ defmodule ExRPC do
     ExRPC.Client.safe_cast(node, m, f, a, send_to)
   end
 
-  @spec pinfo(node, list) :: {:badtcp | :badrpc, any} | list
-  def pinfo(node, a \\ [])
+  @spec pinfo(node, pid, a | nil) :: {:badtcp | :badrpc, any} | list
+  def pinfo(node, pid, a \\ nil)
   when is_atom(node) and is_list(a)
   do
-    ExRPC.Client.call(node, Process, :info, a)
+    ExRPC.Client.call(node, Process, :info, [pid, a])
   end
 
 end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -22,13 +22,25 @@ defmodule ExRPC do
       iex> ExRPC.call(:'exrpc_slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
       true
 
+      iex> ExRPC.call(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
+      true
+
       iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
+      true
+
+      iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       true
 
       iex> ExRPC.safe_cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
+      iex> ExRPC.safe_cast(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
+      true
+
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)
+      {:badrpc, :nodedown}
+
+      iex> ExRPC.call(:'random_node@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       {:badrpc, :nodedown}
 
     ExRPC will try to detect possible issues with the TCP channel on which

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -13,16 +13,19 @@ defmodule ExRPC do
     effectively spreading the load to X processes for X nodes, instead of pushing data
     from every remote node/RPC call into a single `rex` server.
 
+    The first step is start the target server. Example below assumes node name is 
+    target@127.0.0.1 and path to your beam per standard rebar3 location.
+
     You can generally use `ExRPC.call` and `ExRPC.cast` the same way you use
     the `RPC` library, in the following manner:
 
-      iex> ExRPC.call(node, :erlang, :is_atom, [:ok], 1000)
+      iex> ExRPC.call(:'slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
       true
 
-      iex> ExRPC.cast(node, :os, :timestamp)
+      iex> ExRPC.cast(:'slave@127.0.0.1, :os, :timestamp)
       true
 
-      iex> ExRPC.safe_cast(node, :os, :timestamp)
+      iex> ExRPC.safe_cast(:'slave@127.0.0.1, :os, :timestamp)
       true
 
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -14,18 +14,18 @@ defmodule ExRPC do
     from every remote node/RPC call into a single `rex` server.
 
     The first step is start the target server. Example below assumes node name is 
-    target@127.0.0.1 and path to your beam per standard rebar3 location.
+    exrpc_@127.0.0.1 and path to your beam per standard rebar3 location.
 
     You can generally use `ExRPC.call` and `ExRPC.cast` the same way you use
     the `RPC` library, in the following manner:
 
-      iex> ExRPC.call(:'slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
+      iex> ExRPC.call(:'exrpc_slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
       true
 
-      iex> ExRPC.cast(:'slave@127.0.0.1, :os, :timestamp)
+      iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
-      iex> ExRPC.safe_cast(:'slave@127.0.0.1, :os, :timestamp)
+      iex> ExRPC.safe_cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -106,10 +106,10 @@ defmodule ExRPC do
   def pinfo(node, pid, a \\ nil)
   when is_atom(node) and is_pid(pid) and is_atom(a)
   do
-    cond a
+    case a do
         nil -> ExRPC.Client.call(node, Process, :info, [pid, []])
         _ -> ExRPC.Client.call(node, Process, :info, [pid, a])
     end 
- end
+  end
 
 end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -25,6 +25,9 @@ defmodule ExRPC do
       iex> ExRPC.call(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       true
 
+      iex> ExRPC.call(:'random_node@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
+      {:badrpc, :nodedown}
+
       iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
@@ -38,9 +41,6 @@ defmodule ExRPC do
       true
 
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)
-      {:badrpc, :nodedown}
-
-      iex> ExRPC.call(:'random_node@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       {:badrpc, :nodedown}
 
     ExRPC will try to detect possible issues with the TCP channel on which

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -102,4 +102,12 @@ defmodule ExRPC do
     ExRPC.Client.safe_cast(node, m, f, a, send_to)
   end
 
+  @spec pinfo(node, module, function, list) :: {:badtcp | :badrpc, any} | true
+  def pinfo(node, m, f, a \\ [])
+  when is_atom(node) and is_atom(m) and
+       is_atom(f) and is_list(a)
+  do
+    ExRPC.Client.call(node, Process, :info, a)
+  end
+
 end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -104,7 +104,7 @@ defmodule ExRPC do
 
   @spec pinfo(node, pid, a | nil) :: {:badtcp | :badrpc, any} | list
   def pinfo(node, pid, a \\ nil)
-  when is_atom(node) and is_list(a)
+  when is_atom(node) and is_atom(a)
   do
     ExRPC.Client.call(node, Process, :info, [pid, a])
   end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -102,7 +102,7 @@ defmodule ExRPC do
     ExRPC.Client.safe_cast(node, m, f, a, send_to)
   end
 
-  @spec pinfo(node, pid, a | nil) :: {:badtcp | :badrpc, any} | list
+  @spec pinfo(node, pid, atom) :: {:badtcp | :badrpc, any} | list
   def pinfo(node, pid, a \\ nil)
   when is_atom(node) and is_atom(a)
   do

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -102,8 +102,8 @@ defmodule ExRPC do
     ExRPC.Client.safe_cast(node, m, f, a, send_to)
   end
 
-  @spec pinfo(node, module, function, list) :: {:badtcp | :badrpc, any} | true
-  def pinfo(node, m, f, a \\ [])
+  @spec pinfo(node, list) :: {:badtcp | :badrpc, any} | list
+  def pinfo(node, a \\ [])
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a)
   do

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -104,8 +104,7 @@ defmodule ExRPC do
 
   @spec pinfo(node, list) :: {:badtcp | :badrpc, any} | list
   def pinfo(node, a \\ [])
-  when is_atom(node) and is_atom(m) and
-       is_atom(f) and is_list(a)
+  when is_atom(node) and is_list(a)
   do
     ExRPC.Client.call(node, Process, :info, a)
   end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -43,11 +43,11 @@ defmodule ExRPC do
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)
       {:badrpc, :nodedown}
 
-      iex> pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
-      iex> {:status,:waiting} == ExRPC.pinfo(master, pid, :status)
+      iex'...>' pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
+                {:status,:waiting} == ExRPC.pinfo(master, pid, :status)
 
-      iex> pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
-      iex> nil == ExRPC.pinfo(master, pid, :status)
+      iex'...>' pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
+                nil == ExRPC.pinfo(master, pid, :status)
 
     ExRPC will try to detect possible issues with the TCP channel on which
     it operates, both by closely monitoring `gen_tcp` timeouts and by testing

--- a/lib/exrpc/client.ex
+++ b/lib/exrpc/client.ex
@@ -145,7 +145,7 @@ defmodule ExRPC.Client do
     # Perform an in-band RPC call to the remote node
     # asking it to launch a listener for us and return us
     # the port that has been allocated for us
-    case :rpc.call(server_node, ExRPC.Supervisor.Server, :start_child, [node()], conn_to) do
+    case :rpc.call(server_node, :'Elixir.ExRPC.Supervisor.Server', :start_child, [node()], conn_to) do
       {:ok, port} ->
         # Fetching the IP ourselves, since the remote node
         # does not have a straightforward way of returning
@@ -287,7 +287,6 @@ defmodule ExRPC.Client do
     after
       timeout ->
         _ = GenServer.reply(caller, {:badrpc, :timeout})
-        exit({:error, :timeout})
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -125,3 +125,4 @@ defmodule ExRPC.Mixfile do
 
 end
 
+

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule ExRPC.Mixfile do
       start_permanent: Mix.env == :prod,
       language: :elixir,
       elixir: "~> 1.1",
-      deps: [],
+      deps: deps,
       aliases: aliases,
       package: package,
       source_url: "https://github.com/priestjim/exrpc",
@@ -89,6 +89,16 @@ defmodule ExRPC.Mixfile do
       links: %{"github" => "https://github.com/priestjim/exrpc"},
       licenses: ["Apache"]
     ]
+  end
+
+  defp deps do
+    [
+     # Test dependencies
+     {:excoveralls, "~> 0.3", only: :test},
+
+     # Dev dependencies
+     {:earmark, "~> 0.1", only: :dev},
+     {:ex_doc, "~> 0.10", only: :dev}]
   end
 
   defp aliases do

--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,7 @@ defmodule ExRPC.Mixfile do
     ]
   end
 
-  defp aliases d
+  defp aliases do
     [
       test: [&start_epmd/1, "test"],
       c: "compile",
@@ -122,3 +122,6 @@ defmodule ExRPC.Mixfile do
     Mix.Shell.IO.info("Starting distributed Elixir")
     {"", 0} = System.cmd("epmd", ["-daemon"])
   end
+
+end
+

--- a/mix.exs
+++ b/mix.exs
@@ -98,8 +98,8 @@ defmodule ExRPC.Mixfile do
      {:excoveralls, "~> 0.3", only: :test},
 
      # Dev dependencies
-     {:earmark, "~> 0.1", only: :dev :test},
-     {:ex_doc, "~> 0.10", only: :dev :test}]
+     {:earmark, "~> 0.1", only: :dev},
+     {:ex_doc, "~> 0.10", only: :dev}]
   end
 
   defp aliases do

--- a/mix.exs
+++ b/mix.exs
@@ -96,10 +96,6 @@ defmodule ExRPC.Mixfile do
     [
      # Test dependencies
      {:excoveralls, "~> 0.3", only: :test},
-
-     # Dev dependencies
-     {:earmark, "~> 0.1.19", only: :dev},
-     {:ex_doc, "~> 0.10", only: :dev}]
   end
 
   defp aliases do

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,8 @@ defmodule ExRPC.Mixfile do
           "-Werror_handling",
           "-Wrace_conditions"
         ]
-      ]
+      ],
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -98,8 +98,8 @@ defmodule ExRPC.Mixfile do
      {:excoveralls, "~> 0.3", only: :test},
 
      # Dev dependencies
-     {:earmark, "~> 0.1", only: :dev},
-     {:ex_doc, "~> 0.10", only: :dev}]
+     {:earmark, "~> 0.1", only: :dev :test},
+     {:ex_doc, "~> 0.10", only: :dev :test}]
   end
 
   defp aliases do

--- a/mix.exs
+++ b/mix.exs
@@ -95,10 +95,11 @@ defmodule ExRPC.Mixfile do
   defp deps do
     [
      # Test dependencies
-     {:excoveralls, "~> 0.3", only: :test},
+     {:excoveralls, "~> 0.3", only: :test}
+    ]
   end
 
-  defp aliases do
+  defp aliases d
     [
       test: [&start_epmd/1, "test"],
       c: "compile",

--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,7 @@ defmodule ExRPC.Mixfile do
      {:excoveralls, "~> 0.3", only: :test},
 
      # Dev dependencies
-     {:earmark, "~> 0.1", only: :dev},
+     {:earmark, "~> 0.1.19", only: :dev},
      {:ex_doc, "~> 0.10", only: :dev}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -122,5 +122,3 @@ defmodule ExRPC.Mixfile do
     Mix.Shell.IO.info("Starting distributed Elixir")
     {"", 0} = System.cmd("epmd", ["-daemon"])
   end
-
-end

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -1,0 +1,50 @@
+defmodule ExRPC.Test.Functional.Call do
+  use ExUnit.Case
+
+  @master :'exrpc@127.0.0.1'
+  @slave :'exrpc_slave@127.0.0.1'
+  @invalid :'exrpc_invalid@127.0.0.1'
+
+  setup_all do
+    ExRPC.Test.Helper.start_slave_node()
+    on_exit fn() ->
+      ExRPC.Test.Helper.stop_slave_node()
+    end
+    :ok
+  end
+
+  test "Call on invalid node" do
+    assert {:badrpc, :nodedown} = ExRPC.call(@invalid, :os, :timestamp, [])
+  end
+
+  test "Call with valid eponymous function" do
+    assert {_mega, _sec, _micro} = ExRPC.call(@slave, :os, :timestamp, [], 1000)
+  end
+
+  test "Call with invalid eponymous function" do
+    assert {:badrpc, {:'EXIT', {:undef, [{:os,:timestamp_undef, [], []}|_]}}} =
+      ExRPC.call(@slave, :os, :timestamp_undef, [])
+  end
+
+  test "Call with valid anonymous function" do
+    assert {_,"call_anonymous_function"} =
+      ExRPC.call(@master, :erlang, :apply, [fn(a) -> {self(), a} end, ["call_anonymous_function"]])
+  end
+
+  test "Call with invalid anonymous function" do
+    assert {:badrpc, {:'EXIT', {:undef, [{:erlang,:apply, _, _}|_]}}} =
+      ExRPC.call(@master, :erlang, :apply, [fn() -> :os.timestamp_undef() end])
+  end
+
+  test "Call with process exit" do
+    assert {:badrpc, {:'EXIT', :die}} =
+      ExRPC.call(@master, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+  test "Call with call timeout" do
+    assert {:badrpc, :timeout} = ExRPC.call(@slave, :timer, :sleep, [100], 1)
+    # Wait for the remote process to die
+    :timer.sleep(100)
+  end
+
+end

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -1,9 +1,7 @@
 defmodule ExRPC.Test.Functional.Call do
   use ExUnit.Case
-
-  @master :'exrpc@127.0.0.1'
-  @slave :'exrpc_slave@127.0.0.1'
-  @invalid :'exrpc_invalid@127.0.0.1'
+  
+  import ExRPC.Test.Helper
 
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
@@ -13,36 +11,50 @@ defmodule ExRPC.Test.Functional.Call do
     :ok
   end
 
+  test "Call on local node" do
+    assert {_mega, _sec, _micro} = ExRPC.call(invalid, :os, :timestamp, [])
+  end
+
   test "Call on invalid node" do
-    assert {:badrpc, :nodedown} = ExRPC.call(@invalid, :os, :timestamp, [])
+    assert {:badrpc, :nodedown} = ExRPC.call(invalid, :os, :timestamp, [])
   end
 
   test "Call with valid eponymous function" do
-    assert {_mega, _sec, _micro} = ExRPC.call(@slave, :os, :timestamp, [], 1000)
+    assert {_mega, _sec, _micro} = ExRPC.call(slave, :os, :timestamp, [], 1000)
   end
 
   test "Call with invalid eponymous function" do
     assert {:badrpc, {:'EXIT', {:undef, [{:os,:timestamp_undef, [], []}|_]}}} =
-      ExRPC.call(@slave, :os, :timestamp_undef, [])
+      ExRPC.call(slave, :os, :timestamp_undef, [])
   end
 
   test "Call with valid anonymous function" do
     assert {_,"call_anonymous_function"} =
-      ExRPC.call(@master, :erlang, :apply, [fn(a) -> {self(), a} end, ["call_anonymous_function"]])
+      ExRPC.call(master, :erlang, :apply, [fn(a) -> {self(), a} end, ["call_anonymous_function"]])
   end
 
   test "Call with invalid anonymous function" do
     assert {:badrpc, {:'EXIT', {:undef, [{:erlang,:apply, _, _}|_]}}} =
-      ExRPC.call(@master, :erlang, :apply, [fn() -> :os.timestamp_undef() end])
+      ExRPC.call(master, :erlang, :apply, [fn() -> :os.timestamp_undef() end])
   end
 
   test "Call with process exit" do
     assert {:badrpc, {:'EXIT', :die}} =
-      ExRPC.call(@master, :erlang, :apply, [fn() -> exit(:die) end, []])
+      ExRPC.call(master, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+  test "Call local with process throw" do
+    assert :throwMaster =
+      ExRPC.call(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  end
+
+  test "Call slave with process exit" do
+    assert :throwSlave =
+      ExRPC.call(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
   end
 
   test "Call with call timeout" do
-    assert {:badrpc, :timeout} = ExRPC.call(@slave, :timer, :sleep, [100], 1)
+    assert {:badrpc, :timeout} = ExRPC.call(slave, :timer, :sleep, [100], 1)
     # Wait for the remote process to die
     :timer.sleep(100)
   end

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -16,13 +16,12 @@ defmodule ExRPC.Test.Functional.Call do
   end
 
   test "Call on local node mf" do
-    assert ExRPC.Test.Helper.master = ExRPC.call(master, :erlang, :node, [])
+    assert ExRPC.Test.Helper.master = ExRPC.call(master, :erlang, :node)
   end
 
   test "Call on local node mfa" do
     assert [3,2,1] = ExRPC.call(master, :erlang, :apply, [Enum, :reverse, [[1, 2, 3]]])
   end
-
 
   test "Call on invalid node" do
     assert {:badrpc, :nodedown} = ExRPC.call(invalid, :os, :timestamp, [])

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -15,6 +15,15 @@ defmodule ExRPC.Test.Functional.Call do
     assert {_mega, _sec, _micro} = ExRPC.call(master, :os, :timestamp, [])
   end
 
+  test "Call on local node mf" do
+    assert ExRPC.Test.Helper.master = ExRPC.call(master, :erlang, :node, [])
+  end
+
+  test "Call on local node mfa" do
+    assert [3,2,1] = ExRPC.call(master, :erlang, :apply, [Enum, :reverse, [[1, 2, 3]]])
+  end
+
+
   test "Call on invalid node" do
     assert {:badrpc, :nodedown} = ExRPC.call(invalid, :os, :timestamp, [])
   end

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -12,7 +12,7 @@ defmodule ExRPC.Test.Functional.Call do
   end
 
   test "Call on local node" do
-    assert {_mega, _sec, _micro} = ExRPC.call(invalid, :os, :timestamp, [])
+    assert {_mega, _sec, _micro} = ExRPC.call(master, :os, :timestamp, [])
   end
 
   test "Call on invalid node" do
@@ -46,11 +46,6 @@ defmodule ExRPC.Test.Functional.Call do
   test "Call local with process throw" do
     assert :throwMaster =
       ExRPC.call(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
-  end
-
-  test "Call slave with process exit" do
-    assert :throwSlave =
-      ExRPC.call(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
   end
 
   test "Call with call timeout" do

--- a/test/functional/cast_test.exs
+++ b/test/functional/cast_test.exs
@@ -1,0 +1,31 @@
+defmodule ExRPC.Test.Functional.Cast do
+  use ExUnit.Case
+
+  @slave :'exrpc_slave@127.0.0.1'
+  @invalid :'exrpc_invalid@127.0.0.1'
+
+  setup_all do
+    ExRPC.Test.Helper.start_slave_node()
+    on_exit fn() ->
+      ExRPC.Test.Helper.stop_slave_node()
+    end
+    :ok
+  end
+
+  test "Cast" do
+    assert true = ExRPC.cast(@slave, :os, :timestamp, [])
+  end
+
+  test "Cast with invalid function" do
+    assert true = ExRPC.cast(@slave, :os, :timestamp_undef, [])
+  end
+
+  test "Cast on invalid node" do
+    assert true = ExRPC.cast(@invalid, :os, :timestamp, [])
+  end
+
+  test "Cast with process exit" do
+    assert true = ExRPC.cast(@slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+end

--- a/test/functional/cast_test.exs
+++ b/test/functional/cast_test.exs
@@ -15,6 +15,18 @@ defmodule ExRPC.Test.Functional.Cast do
     assert true = ExRPC.cast(slave, :os, :timestamp, [])
   end
 
+  test "Cast on local node mf" do
+    assert true= ExRPC.cast(master, :erlang, :node)
+  end
+
+  test "Cast on local node mfa" do
+    assert true = ExRPC.cast(master, Kernel, :send, [self, {:test, 'wawasing'}])
+    receive do
+        {:test, _} -> true
+        msg ->  :erlang.error RuntimeError.exception(msg) 
+    end
+  end
+
   test "Cast with invalid function" do
     assert true = ExRPC.cast(slave, :os, :timestamp_undef, [])
   end

--- a/test/functional/cast_test.exs
+++ b/test/functional/cast_test.exs
@@ -1,8 +1,7 @@
 defmodule ExRPC.Test.Functional.Cast do
   use ExUnit.Case
 
-  @slave :'exrpc_slave@127.0.0.1'
-  @invalid :'exrpc_invalid@127.0.0.1'
+  import ExRPC.Test.Helper
 
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
@@ -13,19 +12,29 @@ defmodule ExRPC.Test.Functional.Cast do
   end
 
   test "Cast" do
-    assert true = ExRPC.cast(@slave, :os, :timestamp, [])
+    assert true = ExRPC.cast(slave, :os, :timestamp, [])
   end
 
   test "Cast with invalid function" do
-    assert true = ExRPC.cast(@slave, :os, :timestamp_undef, [])
+    assert true = ExRPC.cast(slave, :os, :timestamp_undef, [])
   end
 
   test "Cast on invalid node" do
-    assert true = ExRPC.cast(@invalid, :os, :timestamp, [])
+    assert true = ExRPC.cast(invalid, :os, :timestamp, [])
   end
 
   test "Cast with process exit" do
-    assert true = ExRPC.cast(@slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+    assert true = ExRPC.cast(slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+  test "Call local with process throw" do
+    assert true =
+      ExRPC.cast(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  end
+
+  test "Call slave with process exit" do
+    assert true  =
+      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
   end
 
 end

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -12,43 +12,43 @@ defmodule ExRPC.Test.Functional.Pinfo do
   end
 
   test "Pinfo on living process on local node" do
-    pid = ExRPC.call(master, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(master, Process, :alive?, [pid])
     assert [] != ExRPC.pinfo(master, pid)
   end
 
   test "Pinfo on dead process on local node" do
-    pid = ExRPC.call(master, Process, :spawn, [fn -> Process.exit(self, :normal) end])
+    pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false = ExRPC.call(master, Process, :alive?, [pid])
     assert :undefined = ExRPC.pinfo(master, pid)
   end
 
   test "Pinfo status on living process on local node" do
-    pid = ExRPC.call(master, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(master, Process, :alive?, [pid])
     assert {:status,:waiting}!= ExRPC.pinfo(master, pid, [:status])
   end
 
   test "Pinfo on living process on slave node" do
-    pid = ExRPC.call(slave, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    pid = ExRPC.call(slave, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(slave, Process, :alive?, [pid])
     assert [] != ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo on dead process on slave node" do
-    pid = ExRPC.call(slave, Process, :spawn, [fn -> Process.exit(self, :normal) end])
+    pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false = ExRPC.call(slave, Process, :alive?, [pid])
     assert :undefined = ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo on process that throws on slave node" do
-    pid = ExRPC.call(slave, Process, :spawn, [fn -> throw(:xxxxxx) end])
+    pid = ExRPC.call(slave, Kernel, :spawn, [fn -> throw(:xxxxxx) end])
     assert false = ExRPC.call(slave, Process, :alive?, [pid])
     assert :undefined = ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo status on living process on slave node" do
-    pid = ExRPC.call(slave, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    pid = ExRPC.call(slave, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(slave, Process, :alive?, [pid])
     assert {:status,:waiting}!= ExRPC.pinfo(slave, pid, [:status])
   end

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -26,7 +26,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo status on living process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(master, Process, :alive?, [pid])
-    assert {:status,:waiting}!= ExRPC.pinfo(master, pid, [:status])
+    assert {:status,:waiting}!= ExRPC.pinfo(master, pid, :status)
   end
 
   test "Pinfo on living process on slave node" do
@@ -50,6 +50,6 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo status on living process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(slave, Process, :alive?, [pid])
-    assert {:status,:waiting}!= ExRPC.pinfo(slave, pid, [:status])
+    assert {:status,:waiting}!= ExRPC.pinfo(slave, pid, :status)
   end
 end

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -1,0 +1,55 @@
+defmodule ExRPC.Test.Functional.Pinfo do
+  use ExUnit.Case
+  
+  import ExRPC.Test.Helper
+
+  setup_all do
+    ExRPC.Test.Helper.start_slave_node()
+    on_exit fn() ->
+      ExRPC.Test.Helper.stop_slave_node()
+    end
+    :ok
+  end
+
+  test "Pinfo on living process on local node" do
+    pid = ExRPC.call(master, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    assert true = ExRPC.call(master, Process, :alive?, [pid])
+    assert [] != ExRPC.pinfo(master, pid)
+  end
+
+  test "Pinfo on dead process on local node" do
+    pid = ExRPC.call(master, Process, :spawn, [fn -> Process.exit(self, :normal) end])
+    assert false = ExRPC.call(master, Process, :alive?, [pid])
+    assert :undefined = ExRPC.pinfo(master, pid)
+  end
+
+  test "Pinfo status on living process on local node" do
+    pid = ExRPC.call(master, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    assert true = ExRPC.call(master, Process, :alive?, [pid])
+    assert {:status,:waiting}!= ExRPC.pinfo(master, pid, [:status])
+  end
+
+  test "Pinfo on living process on slave node" do
+    pid = ExRPC.call(slave, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    assert true = ExRPC.call(slave, Process, :alive?, [pid])
+    assert [] != ExRPC.pinfo(slave, pid)
+  end
+
+  test "Pinfo on dead process on slave node" do
+    pid = ExRPC.call(slave, Process, :spawn, [fn -> Process.exit(self, :normal) end])
+    assert false = ExRPC.call(slave, Process, :alive?, [pid])
+    assert :undefined = ExRPC.pinfo(slave, pid)
+  end
+
+  test "Pinfo on process that throws on slave node" do
+    pid = ExRPC.call(slave, Process, :spawn, [fn -> throw(:xxxxxx) end])
+    assert false = ExRPC.call(slave, Process, :alive?, [pid])
+    assert :undefined = ExRPC.pinfo(slave, pid)
+  end
+
+  test "Pinfo status on living process on slave node" do
+    pid = ExRPC.call(slave, Process, :spawn, [fn -> :timer.sleep(100000) end])
+    assert true = ExRPC.call(slave, Process, :alive?, [pid])
+    assert {:status,:waiting}!= ExRPC.pinfo(slave, pid, [:status])
+  end
+end

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -22,7 +22,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false == ExRPC.call(master, Process, :alive?, [pid])
     assert [] = ExRPC.pinfo(master, pid)
-    assert nil = ExRPC.pinfo(master, pid, :status)
+    assert nil == ExRPC.pinfo(master, pid, :status)
   end
 
   test "Pinfo status on living process on local node" do

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -19,7 +19,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on dead process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
-    assert false = ExRPC.call(master, Process, :alive?, [pid])
+    assert false == ExRPC.call(master, Process, :alive?, [pid])
     assert :undefined = ExRPC.pinfo(master, pid)
   end
 
@@ -37,13 +37,13 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
-    assert false = ExRPC.call(slave, Process, :alive?, [pid])
+    assert false == ExRPC.call(slave, Process, :alive?, [pid])
     assert :undefined = ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo on process that throws on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> throw(:xxxxxx) end])
-    assert false = ExRPC.call(slave, Process, :alive?, [pid])
+    assert false == ExRPC.call(slave, Process, :alive?, [pid])
     assert :undefined = ExRPC.pinfo(slave, pid)
   end
 

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -39,7 +39,8 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
-    :timer.sleep(1000)
+    # A bit concerning. Erlang never need to wait this long for remote pid status
+    :timer.sleep(1000) 
     assert false == ExRPC.call(slave, Process, :alive?, [pid])
     assert [] == ExRPC.pinfo(slave, pid)
     assert nil == ExRPC.pinfo(slave, pid, :status)

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -14,45 +14,45 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on living process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
-    assert true = ExRPC.call(master, Process, :alive?, [pid])
-    assert [] = ExRPC.pinfo(master, pid)
+    assert true == ExRPC.call(master, Process, :alive?, [pid])
+    assert [] == ExRPC.pinfo(master, pid)
   end
 
   test "Pinfo on dead process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false == ExRPC.call(master, Process, :alive?, [pid])
-    assert [] = ExRPC.pinfo(master, pid)
+    assert [] == ExRPC.pinfo(master, pid)
     assert nil == ExRPC.pinfo(master, pid, :status)
   end
 
   test "Pinfo status on living process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
-    assert true = ExRPC.call(master, Process, :alive?, [pid])
-    assert {:status,:waiting} = ExRPC.pinfo(master, pid, :status)
+    assert true == ExRPC.call(master, Process, :alive?, [pid])
+    assert {:status,:waiting} == ExRPC.pinfo(master, pid, :status)
   end
 
   test "Pinfo on living process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
-    assert true = ExRPC.call(slave, Process, :alive?, [pid])
-    assert [] = ExRPC.pinfo(slave, pid)
+    assert true == ExRPC.call(slave, Process, :alive?, [pid])
+    assert [] == ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false == ExRPC.call(slave, Process, :alive?, [pid])
-    assert [] = ExRPC.pinfo(slave, pid)
-    assert nil = ExRPC.pinfo(slave, pid, :status)
+    assert [] == ExRPC.pinfo(slave, pid)
+    assert nil == ExRPC.pinfo(slave, pid, :status)
   end
 
   test "Pinfo on process that throws on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> throw(:xxxxxx) end])
-    assert true = ExRPC.call(slave, Process, :alive?, [pid])
-    assert [] = ExRPC.pinfo(slave, pid)
+    assert true == ExRPC.call(slave, Process, :alive?, [pid])
+    assert [] == ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo status on living process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
-    assert true = ExRPC.call(slave, Process, :alive?, [pid])
-    assert {:status,:waiting} = ExRPC.pinfo(slave, pid, :status)
+    assert true == ExRPC.call(slave, Process, :alive?, [pid])
+    assert {:status,:waiting} == ExRPC.pinfo(slave, pid, :status)
   end
 end

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -21,7 +21,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on dead process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false == ExRPC.call(master, Process, :alive?, [pid])
-    assert :undefined = ExRPC.pinfo(master, pid)
+    assert nil = ExRPC.pinfo(master, pid)
   end
 
   test "Pinfo status on living process on local node" do
@@ -39,7 +39,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false == ExRPC.call(slave, Process, :alive?, [pid])
-    assert :undefined = ExRPC.pinfo(slave, pid)
+    assert nil = ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo on process that throws on slave node" do

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -4,6 +4,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   import ExRPC.Test.Helper
 
   setup_all do
+    ExRPC.Test.Helper.start_master_node()
     ExRPC.Test.Helper.start_slave_node()
     on_exit fn() ->
       ExRPC.Test.Helper.stop_slave_node()
@@ -14,7 +15,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on living process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(master, Process, :alive?, [pid])
-    assert [] != ExRPC.pinfo(master, pid)
+    assert [] = ExRPC.pinfo(master, pid)
   end
 
   test "Pinfo on dead process on local node" do
@@ -26,7 +27,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo status on living process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(master, Process, :alive?, [pid])
-    assert {:status,:waiting}!= ExRPC.pinfo(master, pid, :status)
+    assert {:status,:waiting} = ExRPC.pinfo(master, pid, :status)
   end
 
   test "Pinfo on living process on slave node" do
@@ -43,13 +44,13 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on process that throws on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> throw(:xxxxxx) end])
-    assert false == ExRPC.call(slave, Process, :alive?, [pid])
+    assert true == ExRPC.call(slave, Process, :alive?, [pid])
     assert :undefined = ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo status on living process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(slave, Process, :alive?, [pid])
-    assert {:status,:waiting}!= ExRPC.pinfo(slave, pid, :status)
+    assert {:status,:waiting} = ExRPC.pinfo(slave, pid, :status)
   end
 end

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -33,7 +33,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on living process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> :timer.sleep(100000) end])
     assert true = ExRPC.call(slave, Process, :alive?, [pid])
-    assert [] != ExRPC.pinfo(slave, pid)
+    assert [] = ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo on dead process on slave node" do
@@ -45,7 +45,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on process that throws on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> throw(:xxxxxx) end])
     assert true == ExRPC.call(slave, Process, :alive?, [pid])
-    assert :undefined = ExRPC.pinfo(slave, pid)
+    assert [] = ExRPC.pinfo(slave, pid)
   end
 
   test "Pinfo status on living process on slave node" do

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -39,7 +39,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
-    :timer:sleep(1000)
+    :timer.sleep(1000)
     assert false == ExRPC.call(slave, Process, :alive?, [pid])
     assert [] == ExRPC.pinfo(slave, pid)
     assert nil == ExRPC.pinfo(slave, pid, :status)

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -39,7 +39,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     # A bit concerning. Erlang never need to wait this long for remote pid status
-    :timer.sleep(1000) 
+    :timer.sleep(500) 
     assert false == ExRPC.call(slave, Process, :alive?, [pid])
     assert [] == ExRPC.pinfo(slave, pid)
     assert nil == ExRPC.pinfo(slave, pid, :status)
@@ -47,6 +47,12 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on process that throws on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> throw(:xxxxxx) end])
+    assert true == ExRPC.call(slave, Process, :alive?, [pid])
+    assert [] == ExRPC.pinfo(slave, pid)
+  end
+
+  test "Pinfo on process that throws but catch on slave node" do
+    pid = ExRPC.call(slave, Kernel, :spawn, [fn -> try do throw(:xxxxxx) catch any-> any end end])
     assert true == ExRPC.call(slave, Process, :alive?, [pid])
     assert [] == ExRPC.pinfo(slave, pid)
   end

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -4,7 +4,6 @@ defmodule ExRPC.Test.Functional.Pinfo do
   import ExRPC.Test.Helper
 
   setup_all do
-    ExRPC.Test.Helper.start_master_node()
     ExRPC.Test.Helper.start_slave_node()
     on_exit fn() ->
       ExRPC.Test.Helper.stop_slave_node()

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -21,8 +21,8 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on dead process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false == ExRPC.call(master, Process, :alive?, [pid])
-    assert [] = ExRPC.pinfo(slave, pid)
-    assert nil = ExRPC.pinfo(slave, pid, :status)
+    assert [] = ExRPC.pinfo(master, pid)
+    assert nil = ExRPC.pinfo(master, pid, :status)
   end
 
   test "Pinfo status on living process on local node" do
@@ -39,14 +39,14 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
-    assert false = ExRPC.call(slave, Process, :alive?, [pid])
+    assert false == ExRPC.call(slave, Process, :alive?, [pid])
     assert [] = ExRPC.pinfo(slave, pid)
     assert nil = ExRPC.pinfo(slave, pid, :status)
   end
 
   test "Pinfo on process that throws on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> throw(:xxxxxx) end])
-    assert true == ExRPC.call(slave, Process, :alive?, [pid])
+    assert true = ExRPC.call(slave, Process, :alive?, [pid])
     assert [] = ExRPC.pinfo(slave, pid)
   end
 

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -39,6 +39,7 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
+    :timer:sleep(1000)
     assert false == ExRPC.call(slave, Process, :alive?, [pid])
     assert [] == ExRPC.pinfo(slave, pid)
     assert nil == ExRPC.pinfo(slave, pid, :status)

--- a/test/functional/pinfo_test.exs
+++ b/test/functional/pinfo_test.exs
@@ -21,7 +21,8 @@ defmodule ExRPC.Test.Functional.Pinfo do
   test "Pinfo on dead process on local node" do
     pid = ExRPC.call(master, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
     assert false == ExRPC.call(master, Process, :alive?, [pid])
-    assert nil = ExRPC.pinfo(master, pid)
+    assert [] = ExRPC.pinfo(slave, pid)
+    assert nil = ExRPC.pinfo(slave, pid, :status)
   end
 
   test "Pinfo status on living process on local node" do
@@ -38,8 +39,9 @@ defmodule ExRPC.Test.Functional.Pinfo do
 
   test "Pinfo on dead process on slave node" do
     pid = ExRPC.call(slave, Kernel, :spawn, [fn -> Process.exit(self, :normal) end])
-    assert false == ExRPC.call(slave, Process, :alive?, [pid])
-    assert nil = ExRPC.pinfo(slave, pid)
+    assert false = ExRPC.call(slave, Process, :alive?, [pid])
+    assert [] = ExRPC.pinfo(slave, pid)
+    assert nil = ExRPC.pinfo(slave, pid, :status)
   end
 
   test "Pinfo on process that throws on slave node" do

--- a/test/functional/safe_cast_test.exs
+++ b/test/functional/safe_cast_test.exs
@@ -1,0 +1,31 @@
+defmodule ExRPC.Test.Functional.SafeCast do
+  use ExUnit.Case
+
+  @slave :'exrpc_slave@127.0.0.1'
+  @invalid :'exrpc_invalid@127.0.0.1'
+
+  setup_all do
+    ExRPC.Test.Helper.start_slave_node()
+    on_exit fn() ->
+      ExRPC.Test.Helper.stop_slave_node()
+    end
+    :ok
+  end
+
+  test "Safe cast with invalid function" do
+    assert true = ExRPC.safe_cast(@slave, :os, :timestamp_undef, [])
+  end
+
+  test "Safe cast with invalid node" do
+    assert {:badrpc, :nodedown} = ExRPC.safe_cast(@invalid, :os, :timestamp, [])
+  end
+
+  test "Safe cast with process exit" do
+    assert true = ExRPC.safe_cast(@slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+  test "Call to slave node" do
+    assert {_mega, _sec, _micro} = ExRPC.call(@slave, :os, :timestamp, [], 1000)
+  end
+
+end

--- a/test/functional/safe_cast_test.exs
+++ b/test/functional/safe_cast_test.exs
@@ -1,8 +1,7 @@
 defmodule ExRPC.Test.Functional.SafeCast do
   use ExUnit.Case
 
-  @slave :'exrpc_slave@127.0.0.1'
-  @invalid :'exrpc_invalid@127.0.0.1'
+  import ExRPC.Test.Helper
 
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
@@ -13,19 +12,31 @@ defmodule ExRPC.Test.Functional.SafeCast do
   end
 
   test "Safe cast with invalid function" do
-    assert true = ExRPC.safe_cast(@slave, :os, :timestamp_undef, [])
+    assert true = ExRPC.safe_cast(slave, :os, :timestamp_undef, [])
   end
 
   test "Safe cast with invalid node" do
-    assert {:badrpc, :nodedown} = ExRPC.safe_cast(@invalid, :os, :timestamp, [])
+    assert {:badrpc, :nodedown} = ExRPC.safe_cast(invalid, :os, :timestamp, [])
   end
 
   test "Safe cast with process exit" do
-    assert true = ExRPC.safe_cast(@slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+    assert true = ExRPC.safe_cast(slave, :erlang, :apply, [fn() -> exit(:die) end, []])
   end
 
   test "Call to slave node" do
-    assert {_mega, _sec, _micro} = ExRPC.call(@slave, :os, :timestamp, [], 1000)
+    assert true = ExRPC.safe_cast(slave, :os, :timestamp, [], 1000)
   end
+
+
+  test "Call local with process throw" do
+    assert true =
+      ExRPC.safe_cast(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  end
+
+  test "Call slave with process exit" do
+    assert true  =
+      ExRPC.safe_cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+  end
+
 
 end

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -9,7 +9,6 @@ defmodule ExRPC.Test.Moduledoc do
     :ok
   end
 
-
   doctest ExRPC
 
 end

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -1,8 +1,6 @@
 defmodule ExRPC.Test.Moduledoc do
   use ExUnit.Case
 
-  import ExRPC.Test.Helper
-
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
     on_exit fn() ->

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -2,7 +2,7 @@ defmodule ExRPC.Test.Moduledoc do
   use ExUnit.Case
 
   setup_all do
-    ExRPC.Test.Helper.start_slave_node()
+    {:ok, _} = ExRPC.Test.Helper.start_slave_node()
     on_exit fn() ->
       ExRPC.Test.Helper.stop_slave_node()
     end

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -1,0 +1,6 @@
+defmodule ExRPC.Test.Moduledoc do
+  use ExUnit.Case
+
+  doctest ExRPC
+
+end

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -1,6 +1,17 @@
 defmodule ExRPC.Test.Moduledoc do
   use ExUnit.Case
 
+  import ExRPC.Test.Helper
+
+  setup_all do
+    ExRPC.Test.Helper.start_slave_node()
+    on_exit fn() ->
+      ExRPC.Test.Helper.stop_slave_node()
+    end
+    :ok
+  end
+
+
   doctest ExRPC
 
 end

--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -1,11 +1,5 @@
-defmodule ExRPC.Test do
+defmodule ExRPC.Test.Supervisor do
   use ExUnit.Case
-
-  doctest ExRPC
-
-  test "Proper application startup" do
-    assert({:ok, _apps} = Application.ensure_all_started(:exrpc))
-  end
 
   test "Supervisor startup" do
     assert(is_pid(Process.whereis(ExRPC.Supervisor.Application)) === true)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,16 +1,19 @@
 defmodule ExRPC.Test.Helper do
 
-  @master :'exrpc@127.0.0.1'
-  @slave :'exrpc_slave@127.0.0.1'
-  @slave_ip :'127.0.0.1'
-  @slave_name :'exrpc_slave'
+  defmacro master do :'exrpc@127.0.0.1' end
+  defmacro slave do :'exrpc_slave@127.0.0.1' end
+  defmacro slave1 do :'exrpc_slave1@127.0.0.1' end
+  defmacro slave2 do :'exrpc_slave2@127.0.0.1' end
+  defmacro slave_ip do :'127.0.0.1' end
+  defmacro slave_name do :'exrpc_slave' end
+  defmacro invalid do :'exrpc_invalid@127.0.0.1' end
 
   def start_master_node() do
-    case :net_kernel.start([{:longnames, true}, @master]) do
+    case :net_kernel.start([{:longnames, true}, master]) do
       {:ok, _} ->
-        {:ok, {@master, :started}};
+        {:ok, {master, :started}};
       {:error,{:already_started, _pid}} ->
-        {:ok, {@master, :already_started}};
+        {:ok, {master, :already_started}};
       {:error, reason} ->
         {:error, reason}
     end
@@ -20,13 +23,13 @@ defmodule ExRPC.Test.Helper do
   def start_slave_node() do
     cookie = :erlang.get_cookie |> Atom.to_char_list
     erl_flags = ' -kernel dist_auto_connect once +K true -setcookie ' ++ cookie
-    {:ok, _slave} = :slave.start(@slave_ip, @slave_name, erl_flags)
-    :ok = :rpc.call(@slave, :code, :add_pathsz, [:code.get_path()])
-    {:ok, _slave_apps} = :rpc.call(@slave, Application, :ensure_all_started, [:exrpc])
+    {:ok, _slave} = :slave.start(slave_ip, slave_name, erl_flags)
+    :ok = :rpc.call(slave, :code, :add_pathsz, [:code.get_path()])
+    {:ok, _slave_apps} = :rpc.call(slave, Application, :ensure_all_started, [:exrpc])
   end
 
   def stop_slave_node() do
-    :ok = :slave.stop(@slave)
+    :ok = :slave.stop(slave)
   end
 
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -21,15 +21,23 @@ defmodule ExRPC.Test.Helper do
   end
 
   def start_slave_node() do
+    start_slave_node(slave_name, slave)
+  end
+
+  def start_slave_node(node_name, node_full_name) do
     cookie = :erlang.get_cookie |> Atom.to_char_list
     erl_flags = ' -kernel dist_auto_connect once +K true -setcookie ' ++ cookie
-    {:ok, _slave} = :slave.start(slave_ip, slave_name, erl_flags)
+    {:ok, _slave} = :slave.start(slave_ip, node_name, erl_flags)
     :ok = :rpc.call(slave, :code, :add_pathsz, [:code.get_path()])
-    {:ok, _slave_apps} = :rpc.call(slave, Application, :ensure_all_started, [:exrpc])
+    {:ok, _slave_apps} = :rpc.call(node_full_name, Application, :ensure_all_started, [:exrpc])
   end
 
   def stop_slave_node() do
     :ok = :slave.stop(slave)
+  end
+
+  def stop_slave_node(node_name) do
+    :ok = :slave.stop(node_name)
   end
 
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,36 @@
+defmodule ExRPC.Test.Helper do
+
+  @master :'exrpc@127.0.0.1'
+  @slave :'exrpc_slave@127.0.0.1'
+  @slave_ip :'127.0.0.1'
+  @slave_name :'exrpc_slave'
+
+  def start_master_node() do
+    case :net_kernel.start([{:longnames, true}, @master]) do
+      {:ok, _} ->
+        {:ok, {@master, :started}};
+      {:error,{:already_started, _pid}} ->
+        {:ok, {@master, :already_started}};
+      {:error, reason} ->
+        {:error, reason}
+    end
+    {:ok, _master_apps} = Application.ensure_all_started(:exrpc)
+  end
+
+  def start_slave_node() do
+    cookie = :erlang.get_cookie |> Atom.to_char_list
+    erl_flags = ' -kernel dist_auto_connect once +K true -setcookie ' ++ cookie
+    {:ok, _slave} = :slave.start(@slave_ip, @slave_name, erl_flags)
+    :ok = :rpc.call(@slave, :code, :add_pathsz, [:code.get_path()])
+    {:ok, _slave_apps} = :rpc.call(@slave, Application, :ensure_all_started, [:exrpc])
+  end
+
+  def stop_slave_node() do
+    :ok = :slave.stop(@slave)
+  end
+
+end
+
 ExUnit.start()
-ExUnit.configure(seed: 0)
-:net_kernel.start([{:longnames, true}, :'exrpc@127.0.0.1'])
+ExUnit.configure(seed: 0, max_cases: 1)
+ExRPC.Test.Helper.start_master_node()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,7 +9,7 @@ defmodule ExRPC.Test.Helper do
   defmacro invalid do :'exrpc_invalid@127.0.0.1' end
 
   def start_master_node() do
-    case :net_kernel.start([{:longnames, true}, master]) do
+    case Node.start(master, :longnames) do
       {:ok, _} ->
         {:ok, {master, :started}};
       {:error,{:already_started, _pid}} ->


### PR DESCRIPTION
- added pinfo implementation and tests

NB:
- Elixir sometime returns different value from underlying erlang library (e.g. erlang:porocess_info undefined wil become nil etc.
- It doesseem like pid status from remote node does not propagae as quick (see tests 
  test "Pinfo on dead process on slave node"  vs on local node. I need to add a timeout for ?alive  to show the pid has exited
- libraries are ot stable yet (hex unable to run in older version)
