### PR TITLE
Async, yield, await implementation. Semantics closer to Elixir.Task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _*
 *.swo
 *.*~
 *~
+*.log
 .erlang.cookie
 .DS_Store
 ebin

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ elixir:
 otp_release:
   - 18.1
   - 18.0
+  - 17.5
+  - 17.4
+  - 17.3
+  - 17.0
 install: "true"
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ elixir:
 otp_release:
   - 18.1
   - 18.0
+  - 17.5
+  - 17.4
+  - 17.3
+  - 17.0
 install: "true"
 branches:
   only:
     - master
     - develop
-script: "make test dialyzer"
+script: "make test"
 cache:
   directories:
   - _plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ branches:
     - master
     - develop
 script: "make test dialyzer"
+after_success:
+  - mix do compile, coveralls.travis
+after_script:
+  - MIX_ENV=docs mix deps.get
+  - MIX_ENV=docs mix inch.report
 cache:
   directories:
   - _plt
@@ -22,4 +27,3 @@ cache:
 notifications:
   email:
     - priestjim@gmail.com
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ branches:
     - master
     - develop
 
+before_script:
+  - mix local.hex --force
+  - mix deps.get --only test
+
 script: "make test"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ branches:
     - master
     - develop
 
-before_script:
-  - mix local.hex --force
-  - mix deps.get --only test
-
 script: "make test"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install: "true"
 branches:
   only:
     - master
+    - develop
 script: "make test dialyzer"
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ otp_release:
   - 18.0
   - 17.5
   - 17.4
-  - 17.3
-  - 17.0
+
 install: "true"
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ branches:
 script: "make test dialyzer"
 after_success:
   - mix do compile, coveralls.travis
-after_script:
-  - MIX_ENV=docs mix deps.get
-  - MIX_ENV=docs mix inch.report
 cache:
   directories:
   - _plt

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ PLT_FILE := _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt
 # =============================================================================
 
 all:
+	@MIX_ENV=dev $(MIX) deps.get && $(MIX) local.hex --force 
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ endif
 # =============================================================================
 ERL = $(shell which erl 2> /dev/null)
 ELIXIR = $(shell which elixir 2> /dev/null)
+MIX = $(shell which mix 2> /dev/null)
 IEX = $(shell which iex 2> /dev/null)
 DIALYXIR = $(shell mix help 2> /dev/null | grep dialyzer.plt)
 DIALYXIR_URL = https://github.com/jeremyjh/dialyxir.git
@@ -52,6 +53,9 @@ ifeq ($(IEX),)
 	$(error "IEx is not available on this system")
 endif
 
+ifeq ($(IEX),)
+	$(error "IEx is not available on this system")
+endif
 # Dialyzer
 ERLANG_VERSION := $(shell $(ERL) -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().' -noshell)
 ELIXIR_VERSION := $(shell $(ELIXIR) -v | cut -d\  -f2 | sed -e 's/-dev//')
@@ -65,6 +69,7 @@ all:
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all
+	@yes | $(MIX) local.rebar && yes | $(MIX) local.hex 
 	@MIX_ENV=test $(ELIXIR) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix t
 
 dialyzer: _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt all

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ all:
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all
+	@MIX_ENV=test $(MIX) deps.get && $(MIX) local.hex --force 
 	@MIX_ENV=test $(ELIXIR) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix t
 
 dialyzer: _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt all

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ all:
 	@MIX_ENV=dev $(ELIXIR) -S mix c
 
 test: epmd all
-	@yes | $(MIX) local.rebar && yes | $(MIX) local.hex 
 	@MIX_ENV=test $(ELIXIR) --name exrpc@127.0.0.1 --cookie exrpc --erl "-args_file config/vm.args" -S mix t
 
 dialyzer: _plt/otp-$(ERLANG_VERSION)_elixir-$(ELIXIR_VERSION).plt all

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -102,4 +102,51 @@ defmodule ExRPC do
     ExRPC.Client.safe_cast(node, m, f, a, send_to)
   end
 
+  @doc """
+    Performs an ExRPC `async_call`, by automatically connecting to a remote `node` and
+    sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
+    (an asynchronous cast). In contrast to the simple `cast` functin, this function will
+    return an error if the connection to the remote node fails (hence the `safe` prefix).
+  """
+  @spec async_call(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
+  def async_call(node, m, f, a \\ [], send_to \\ nil)
+  when is_atom(node) and is_atom(m) and
+       is_atom(f) and is_list(a) and
+       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+  do
+    ExRPC.Client.async_call(node, m, f, a, send_to)
+  end
+
+  @doc """
+    Performs an ExRPC `yield`, by automatically connecting to a remote `node` and
+    sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
+    (an asynchronous cast). In contrast to the simple `cast` functin, this function will
+    return an error if the connection to the remote node fails (hence the `safe` prefix).
+  """
+  @spec yield(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
+  def yield(node, m, f, a \\ [], send_to \\ nil)
+  when is_atom(node) and is_atom(m) and
+       is_atom(f) and is_list(a) and
+       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+  do
+    ExRPC.Client.yield(node, m, f, a, send_to)
+  end
+
+  @doc """
+    Performs an ExRPC `nb_yield`, by automatically connecting to a remote `node` and
+    sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
+    (an asynchronous cast). In contrast to the simple `cast` functin, this function will
+    return an error if the connection to the remote node fails (hence the `safe` prefix).
+  """
+  @spec nb_yield(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
+  def nb_yield(node, m, f, a \\ [], send_to \\ nil)
+  when is_atom(node) and is_atom(m) and
+       is_atom(f) and is_list(a) and
+       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+  do
+    ExRPC.Client.nb_yield(node, m, f, a, send_to)
+  end
+
+
+
 end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -64,21 +64,6 @@ defmodule ExRPC do
   """
 
   # ===================================================
-  # User defined guard Macro
-  # ===================================================
-  defmacro is_proper_timeout(timeout_ast) do
-     quote do
-        is_nil(unquote(timeout_ast)) or (is_integer(unquote(timeout_ast)) and unquote(timeout_ast) >= 0 ) or unquote(timeout_ast) === :infinity
-     end
-  end
-
-  defmacro is_key(key_ast) do
-     quote do
-        is_pid(unquote(key_ast)) or is_reference(unquote(key_ast)) 
-     end
-  end
-
-  # ===================================================
   # Public API
   # ===================================================
 
@@ -94,10 +79,6 @@ defmodule ExRPC do
   """
   @spec call(node, module, function, list, timeout | nil, timeout | nil) :: {:badtcp | :badrpc, any} | any
   def call(node, m, f, a \\ [], recv_to \\ nil, send_to \\ nil)
-  when is_atom(node) and is_atom(m) and
-       is_atom(f) and is_list(a) and
-       is_proper_timeout(recv_to) and
-       is_proper_timeout(send_to)
   do
     ExRPC.Client.call(node, m, f, a, recv_to, send_to)
   end
@@ -109,9 +90,6 @@ defmodule ExRPC do
   """
   @spec cast(node, module, function, list, timeout | nil) :: true
   def cast(node, m, f, a \\ [], send_to \\ nil)
-  when is_atom(node) and is_atom(m) and
-       is_atom(f) and is_list(a) and
-       is_proper_timeout(send_to)
   do
     ExRPC.Client.cast(node, m, f, a, send_to)
   end
@@ -124,9 +102,6 @@ defmodule ExRPC do
   """
   @spec safe_cast(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
   def safe_cast(node, m, f, a \\ [], send_to \\ nil)
-  when is_atom(node) and is_atom(m) and
-       is_atom(f) and is_list(a) and
-       is_proper_timeout(send_to)
   do
     ExRPC.Client.safe_cast(node, m, f, a, send_to)
   end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -52,10 +52,10 @@ defmodule ExRPC do
       described in the agents documentation apply to the whole ecosystem.
 
       iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.await()
-      {:ok, "hello\n"}
+      "hello\n"
 
       iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.yield(5000)
-      "hello\n"
+      {:ok, "hello\n"}
 
     ExRPC will try to detect possible issues with the TCP channel on which
     it operates, both by closely monitoring `gen_tcp` timeouts and by testing

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -64,6 +64,15 @@ defmodule ExRPC do
   """
 
   # ===================================================
+  # Private Macro
+  # ===================================================
+  defmacro is_proper_timeout(timeout) do
+     quote do
+        is_nil(unquote(timeout)) or (is_integer(unquote(timeout)) and unquote(timeout) >= 0 ) or unquote(timeout) === :infinity
+     end
+  end
+
+  # ===================================================
   # Public API
   # ===================================================
 
@@ -81,8 +90,8 @@ defmodule ExRPC do
   def call(node, m, f, a \\ [], recv_to \\ nil, send_to \\ nil)
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(recv_to) or is_integer(recv_to) or recv_to === :infinity) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(recv_to) and
+       is_proper_timeout(send_to)
   do
     ExRPC.Client.call(node, m, f, a, recv_to, send_to)
   end
@@ -96,7 +105,7 @@ defmodule ExRPC do
   def cast(node, m, f, a \\ [], send_to \\ nil)
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(send_to)
   do
     ExRPC.Client.cast(node, m, f, a, send_to)
   end
@@ -111,7 +120,7 @@ defmodule ExRPC do
   def safe_cast(node, m, f, a \\ [], send_to \\ nil)
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(send_to)
   do
     ExRPC.Client.safe_cast(node, m, f, a, send_to)
   end
@@ -125,8 +134,7 @@ defmodule ExRPC do
   @spec async(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
   def async(node, m, f, a \\ [], send_to \\ nil)
   when is_atom(node) and is_atom(m) and
-       is_atom(f) and is_list(a) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_atom(f) and is_list(a)
   do
     ExRPC.Client.async(node, m, f, a, send_to)
   end
@@ -141,7 +149,7 @@ defmodule ExRPC do
   def yield(node, m, f, a \\ [], send_to \\ nil)
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(send_to)
   do
     ExRPC.Client.yield(node, m, f, a, send_to)
   end
@@ -156,7 +164,7 @@ defmodule ExRPC do
   def await(node, m, f, a \\ [], send_to \\ nil)
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(send_to)
   do
     ExRPC.Client.await(node, m, f, a, send_to)
   end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -22,13 +22,25 @@ defmodule ExRPC do
       iex> ExRPC.call(:'exrpc_slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
       true
 
+      iex> ExRPC.call(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
+      true
+
       iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
+      true
+
+      iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       true
 
       iex> ExRPC.safe_cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
+      iex> ExRPC.safe_cast(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
+      true
+
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)
+      {:badrpc, :nodedown}
+
+      iex> ExRPC.call(:'random_node@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       {:badrpc, :nodedown}
 
     ExRPC will try to detect possible issues with the TCP channel on which

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -13,16 +13,19 @@ defmodule ExRPC do
     effectively spreading the load to X processes for X nodes, instead of pushing data
     from every remote node/RPC call into a single `rex` server.
 
+    The first step is start the target server. Example below assumes node name is 
+    target@127.0.0.1 and path to your beam per standard rebar3 location.
+
     You can generally use `ExRPC.call` and `ExRPC.cast` the same way you use
     the `RPC` library, in the following manner:
 
-      iex> ExRPC.call(node, :erlang, :is_atom, [:ok], 1000)
+      iex> ExRPC.call(:'slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
       true
 
-      iex> ExRPC.cast(node, :os, :timestamp)
+      iex> ExRPC.cast(:'slave@127.0.0.1, :os, :timestamp)
       true
 
-      iex> ExRPC.safe_cast(node, :os, :timestamp)
+      iex> ExRPC.safe_cast(:'slave@127.0.0.1, :os, :timestamp)
       true
 
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -14,18 +14,18 @@ defmodule ExRPC do
     from every remote node/RPC call into a single `rex` server.
 
     The first step is start the target server. Example below assumes node name is 
-    target@127.0.0.1 and path to your beam per standard rebar3 location.
+    exrpc_@127.0.0.1 and path to your beam per standard rebar3 location.
 
     You can generally use `ExRPC.call` and `ExRPC.cast` the same way you use
     the `RPC` library, in the following manner:
 
-      iex> ExRPC.call(:'slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
+      iex> ExRPC.call(:'exrpc_slave@127.0.0.1', :erlang, :is_atom, [:ok], 1000)
       true
 
-      iex> ExRPC.cast(:'slave@127.0.0.1, :os, :timestamp)
+      iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
-      iex> ExRPC.safe_cast(:'slave@127.0.0.1, :os, :timestamp)
+      iex> ExRPC.safe_cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -51,10 +51,10 @@ defmodule ExRPC do
       documentation for more information on distributed processes as the limitations
       described in the agents documentation apply to the whole ecosystem.
 
-      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> Task.await()
+      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.await()
       "hello\n"
 
-      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> Task.await()
+      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.await()
       "hello\n"
 
     ExRPC will try to detect possible issues with the TCP channel on which

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -52,7 +52,7 @@ defmodule ExRPC do
       described in the agents documentation apply to the whole ecosystem.
 
       iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.await()
-      "hello\n"
+      {:ok, "hello\n"}
 
       iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.yield(5000)
       "hello\n"

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -25,6 +25,9 @@ defmodule ExRPC do
       iex> ExRPC.call(:'exrpc_slave@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       true
 
+      iex> ExRPC.call(:'random_node@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
+      {:badrpc, :nodedown}
+
       iex> ExRPC.cast(:'exrpc_slave@127.0.0.1', :os, :timestamp)
       true
 
@@ -38,9 +41,6 @@ defmodule ExRPC do
       true
 
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)
-      {:badrpc, :nodedown}
-
-      iex> ExRPC.call(:'random_node@127.0.0.1', Kernel, :is_atom, [:ok], 1000)
       {:badrpc, :nodedown}
 
     ExRPC will try to detect possible issues with the TCP channel on which

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -43,6 +43,20 @@ defmodule ExRPC do
       iex> ExRPC.safe_cast(:'random_node@127.0.0.1', :os, :timestamp)
       {:badrpc, :nodedown}
 
+      Direct rip out from elixir Task.ex doc:
+      Note that, when working with distributed tasks, one should use the `async/4` function
+      that expects explicit module, function and arguments, instead of `async/2` that
+      works with anonymous functions. That's because anonymous functions expect
+      the same module version to exist on all involved nodes. Check the `Agent` module
+      documentation for more information on distributed processes as the limitations
+      described in the agents documentation apply to the whole ecosystem.
+
+      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> Task.await()
+      "hello\n"
+
+      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> Task.await()
+      "hello\n"
+
     ExRPC will try to detect possible issues with the TCP channel on which
     it operates, both by closely monitoring `gen_tcp` timeouts and by testing
     connectivity through the Erlang VM for `every single request`, thus ensuring
@@ -103,18 +117,18 @@ defmodule ExRPC do
   end
 
   @doc """
-    Performs an ExRPC `async_call`, by automatically connecting to a remote `node` and
+    Performs an ExRPC `async`, by automatically connecting to a remote `node` and
     sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
     (an asynchronous cast). In contrast to the simple `cast` functin, this function will
     return an error if the connection to the remote node fails (hence the `safe` prefix).
   """
-  @spec async_call(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
-  def async_call(node, m, f, a \\ [], send_to \\ nil)
+  @spec async(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
+  def async(node, m, f, a \\ [], send_to \\ nil)
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
        (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
   do
-    ExRPC.Client.async_call(node, m, f, a, send_to)
+    ExRPC.Client.async(node, m, f, a, send_to)
   end
 
   @doc """
@@ -133,20 +147,17 @@ defmodule ExRPC do
   end
 
   @doc """
-    Performs an ExRPC `nb_yield`, by automatically connecting to a remote `node` and
+    Performs an ExRPC `await`, by automatically connecting to a remote `node` and
     sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
     (an asynchronous cast). In contrast to the simple `cast` functin, this function will
     return an error if the connection to the remote node fails (hence the `safe` prefix).
   """
-  @spec nb_yield(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
-  def nb_yield(node, m, f, a \\ [], send_to \\ nil)
+  @spec await(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
+  def await(node, m, f, a \\ [], send_to \\ nil)
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
        (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
   do
-    ExRPC.Client.nb_yield(node, m, f, a, send_to)
+    ExRPC.Client.await(node, m, f, a, send_to)
   end
-
-
-
 end

--- a/lib/exrpc.ex
+++ b/lib/exrpc.ex
@@ -54,7 +54,7 @@ defmodule ExRPC do
       iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.await()
       "hello\n"
 
-      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.await()
+      iex'...>' ExRPC.async(:'exrpc_slave@127.0.0.1', IO, :puts, ["hello"]) |> ExRPC.yield(5000)
       "hello\n"
 
     ExRPC will try to detect possible issues with the TCP channel on which
@@ -127,23 +127,19 @@ defmodule ExRPC do
 
   @doc """
     Performs an ExRPC `async`, by automatically connecting to a remote `node` and
-    sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
-    (an asynchronous cast). In contrast to the simple `cast` functin, this function will
-    return an error if the connection to the remote node fails (hence the `safe` prefix).
+    sending a "protected" {`m`,`f`,`a`} call that will be executed without the caller waiting.
+     A 'reference' is returned containing the information to ask for the execution result.
   """
-  @spec async(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
-  def async(node, m, f, a \\ [], send_to \\ nil)
+  @spec async(node, module, function, list | nil) :: {:badtcp | :badrpc, any} | true
+  def async(node, m, f, a \\ [])
   when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a)
   do
-    ExRPC.Client.async(node, m, f, a, send_to)
+    ExRPC.Client.async(node, m, f, a)
   end
 
   @doc """
-    Performs an ExRPC `yield`, by automatically connecting to a remote `node` and
-    sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
-    (an asynchronous cast). In contrast to the simple `cast` functin, this function will
-    return an error if the connection to the remote node fails (hence the `safe` prefix).
+    Performs an ExRPC `yield`.  Awaits a task reply.
   """
   @spec yield(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
   def yield(node, m, f, a \\ [], send_to \\ nil)
@@ -155,10 +151,7 @@ defmodule ExRPC do
   end
 
   @doc """
-    Performs an ExRPC `await`, by automatically connecting to a remote `node` and
-    sending a "protected" {`m`,`f`,`a`} call that will execute but never return the result
-    (an asynchronous cast). In contrast to the simple `cast` functin, this function will
-    return an error if the connection to the remote node fails (hence the `safe` prefix).
+    Performs an ExRPC `await`. Awaits a task reply.
   """
   @spec await(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
   def await(node, m, f, a \\ [], send_to \\ nil)

--- a/lib/exrpc/client.ex
+++ b/lib/exrpc/client.ex
@@ -62,8 +62,8 @@ defmodule ExRPC.Client do
   def call(server_node, m, f, a \\ [], recv_to \\ nil, send_to \\ nil)
   when is_atom(server_node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(recv_to) or is_integer(recv_to) or recv_to === :infinity) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(recv_to) and
+       is_proper_timeout(send_to)
   do
     # Naming our gen_server as the node we're calling as it is extremely efficent:
     # We'll never deplete atoms because all connected node names are already atoms in this VM
@@ -90,9 +90,9 @@ defmodule ExRPC.Client do
   """
   @spec cast(node, module, function, list, timeout | nil) :: true
   def cast(server_node, m, f, a \\ [], send_to \\ nil)
-  when is_atom(server_node) and is_atom(m) and
+  when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(send_to)
   do
     case GenServer.whereis(server_node) do
       nil ->
@@ -120,9 +120,9 @@ defmodule ExRPC.Client do
   """
   @spec safe_cast(node, module, function, list, timeout | nil) :: {:badtcp | :badrpc, any} | true
   def safe_cast(server_node, m, f, a \\ [], send_to \\ nil)
-  when is_atom(server_node) and is_atom(m) and
+  when is_atom(node) and is_atom(m) and
        is_atom(f) and is_list(a) and
-       (is_nil(send_to) or is_integer(send_to) or send_to === :infinity)
+       is_proper_timeout(send_to)
   do
     case GenServer.whereis(server_node) do
       nil ->

--- a/lib/exrpc/client.ex
+++ b/lib/exrpc/client.ex
@@ -173,7 +173,7 @@ defmodule ExRPC.Client do
     settings = Application.get_all_env(:exrpc)
     recv_to = Keyword.get(settings, :receive_timeout)
     {recv_to, _} = merge_timeout_values(recv_to, timeout, nil, nil)
-    normalize_reply(Task.await(task, recv_to))  
+    normalize_reply(Task.await(task, recv_to))
   end
 
   # ===================================================
@@ -384,12 +384,9 @@ defmodule ExRPC.Client do
   defp normalize_reply(fun)
   do
     case fun do
-      {:ok, reply} -> {reply}
-      {:EXIT, reason} -> {:badrpc, reason}
-      {:exit, reason} -> {:badrpc, reason}
-      {:badrpc, reason} ->  {:badrpc, reason}
-      {:badtcp, reason} ->  {:badtcp, reason} 
-      unknown ->  {:badrpc, unknown} 
+      {:ok, {:badrpc, reason}} -> {:badrpc, reason}
+      {:ok, {:badtcp, reason}} -> {:badtcp, reason}
+      reply ->  reply
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule ExRPC.Mixfile do
       start_permanent: Mix.env == :prod,
       language: :elixir,
       elixir: "~> 1.1",
-      deps: [],
+      deps: deps,
       aliases: aliases,
       package: package,
       source_url: "https://github.com/priestjim/exrpc",
@@ -89,6 +89,16 @@ defmodule ExRPC.Mixfile do
       links: %{"github" => "https://github.com/priestjim/exrpc"},
       licenses: ["Apache"]
     ]
+  end
+
+  defp deps do
+    [
+     # Test dependencies
+     {:excoveralls, "~> 0.3", only: :test},
+
+     # Dev dependencies
+     {:earmark, "~> 0.1", only: :dev},
+     {:ex_doc, "~> 0.10", only: :dev}]
   end
 
   defp aliases do

--- a/mix.exs
+++ b/mix.exs
@@ -98,8 +98,8 @@ defmodule ExRPC.Mixfile do
      {:excoveralls, "~> 0.3", only: :test},
 
      # Dev dependencies
-     {:earmark, "~> 0.1", only: :dev :test},
-     {:ex_doc, "~> 0.10", only: :dev :test}]
+     {:earmark, "~> 0.1", only: :dev},
+     {:ex_doc, "~> 0.10", only: :dev}]
   end
 
   defp aliases do

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,8 @@ defmodule ExRPC.Mixfile do
           "-Werror_handling",
           "-Wrace_conditions"
         ]
-      ]
+      ],
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -98,8 +98,8 @@ defmodule ExRPC.Mixfile do
      {:excoveralls, "~> 0.3", only: :test},
 
      # Dev dependencies
-     {:earmark, "~> 0.1", only: :dev},
-     {:ex_doc, "~> 0.10", only: :dev}]
+     {:earmark, "~> 0.1", only: :dev :test},
+     {:ex_doc, "~> 0.10", only: :dev :test}]
   end
 
   defp aliases do

--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,7 @@ defmodule ExRPC.Mixfile do
      {:excoveralls, "~> 0.3", only: :test},
 
      # Dev dependencies
-     {:earmark, "~> 0.1", only: :dev},
+     {:earmark, "~> 0.1.19", only: :dev},
      {:ex_doc, "~> 0.10", only: :dev}]
   end
 

--- a/test/functional/async_test.exs
+++ b/test/functional/async_test.exs
@@ -1,0 +1,67 @@
+defmodule ExRPC.Test.Functional.Async do
+  use ExUnit.Case
+
+  import ExRPC.Test.Helper
+
+  setup_all do
+    ExRPC.Test.Helper.start_slave_node()
+    on_exit fn() ->
+      ExRPC.Test.Helper.stop_slave_node()
+    end
+    :ok
+  end
+
+  setup do
+    on_exit fn -> Logger.add_backend(:console, flush: true) end
+    :ok
+  end
+
+  test "Async" do
+    assert true = ExRPC.cast(slave, :os, :timestamp, [])
+  end
+
+  test "Async on local node mf" do
+    assert true= ExRPC.cast(master, :erlang, :node)
+  end
+
+  test "Async on local node mfa" do
+    assert true = ExRPC.cast(master, Kernel, :send, [self, {:test, 'wawasing'}])
+    receive do
+        {:test, _} -> true
+        msg ->  :erlang.error RuntimeError.exception(msg) 
+    end
+  end
+
+  test "Async with invalid function" do
+    assert true = ExRPC.cast(slave, :os, :timestamp_undef, [])
+  end
+
+  test "Async on invalid node" do
+    assert true = ExRPC.cast(invalid, :os, :timestamp, [])
+  end
+
+  test "Async with process exit" do
+    assert true = ExRPC.cast(slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+  test "Async local with process throw" do
+    assert true =
+      ExRPC.cast(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  end
+
+  test "Async slave with process exit" do
+    assert true  =
+      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+  end
+
+  test "Await cannot reuse reference" do
+    assert true  =
+      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+  end
+
+  test "Async slave with process exit" do
+    assert true  =
+      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+  end
+
+end

--- a/test/functional/async_test.exs
+++ b/test/functional/async_test.exs
@@ -70,6 +70,7 @@ defmodule ExRPC.Test.Functional.Async do
 
   test "Await cannot reuse reference" do
     task = ExRPC.async(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+
   end
 
   test "Async slave with process exit on remote node" do

--- a/test/functional/async_test.exs
+++ b/test/functional/async_test.exs
@@ -22,15 +22,16 @@ defmodule ExRPC.Test.Functional.Async do
     task = ExRPC.async(slave, :os, :timestamp, [])
     assert {_,_,_} =  ExRPC.await(task) 
     task = ExRPC.async(slave, :os, :timestamp, [])
-    assert {_,_,_} =  ExRPC.yield(task, 1000)
+    assert {:ok, {_,_,_}} =  ExRPC.yield(task, 1000)
     task = ExRPC.async(slave, :os, :timestamp, [])
-    assert {_,_,_} =  ExRPC.yield(task) 
+    assert {:ok, {_,_,_}} =  ExRPC.yield(task) 
   end
 
   test "Async on local node mf" do
     task = ExRPC.async(master, :erlang, :node)
-    assert master ===  ExRPC.await(task, 1000)
-
+    assert master === ExRPC.await(task, 1000)
+    task = ExRPC.async(master, :erlang, :node, [])
+    assert {:ok, master} === ExRPC.yield(task, 10)
   end
 
   test "Async on local node mfa" do
@@ -39,13 +40,16 @@ defmodule ExRPC.Test.Functional.Async do
         {:test, _} -> true
         msg ->  :erlang.error RuntimeError.exception(msg) 
     end
-     assert master ===  ExRPC.await(task, 1000)   
-
+    assert {:test, 'wawasing'} =  ExRPC.await(task, 1000)   
+    task = ExRPC.async(master, Kernel, :send, [self, {'yatbaryatbaryatbar'}])
+    assert {'yatbaryatbaryatbar'} =  ExRPC.await(task, 1000) 
   end
 
   test "Async with invalid function" do
+    task = ExRPC.async(master, :os, :timestamp_undef, [])
+    assert {:badrpc, {:EXIT, {:undef, _}}} = ExRPC.yield(task, 1000)
     task = ExRPC.async(slave, :os, :timestamp_undef, [])
-    assert {:badrpc,  _} = ExRPC.await(task, 1000)
+    assert {:badrpc, {:EXIT, {:undef, _}}} = ExRPC.await(task, 1000)
   end
 
   test "Async on invalid node" do
@@ -54,38 +58,53 @@ defmodule ExRPC.Test.Functional.Async do
   end
 
   test "Async with process exit on local node" do
-    task =  ExRPC.async(master, :erlang, :apply, [fn() -> exit(:die) end, []])
-    assert :die === ExRPC.await(task, 1000)
+    task =  ExRPC.async(master, :erlang, :apply, [fn -> exit :die end, []])
+    assert {:badrpc, {:EXIT, :die}} === ExRPC.await(task, 1000)
   end
 
   test "Async with process throw on local node" do
-    task = ExRPC.async(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
-    assert :throwmaster === ExRPC.await(task, 1000)
+    task = ExRPC.async(master, :erlang, :apply, [fn -> throw :throwMaster end, []])
+    assert :throwMaster === ExRPC.await(task, 1000)
   end
 
   test "Async slave with process timeout on local node" do
-    task = ExRPC.async(slave, :erlang, :apply, [fn() -> :timer.sleep(10000) end, []])
-    assert {:badrpc, :timeout} === ExRPC.await(task, 1000)
+    task = ExRPC.async(master, :erlang, :apply, [fn() -> :timer.sleep(10000) end, []])
+    assert catch_exit(ExRPC.await(task, 1000) == {:timeout, {Task, :await, [task, 1000]}})
   end
 
   test "Await cannot reuse reference" do
-    task = ExRPC.async(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
-
+    task = ExRPC.async(master, Kernel, :throw, [:throwSlave])
+    assert {:ok, :throwSlave} === ExRPC.yield(task, 1000)
+    assert nil === ExRPC.yield(task, 1000)
+    assert catch_exit(ExRPC.await(task, 1000) == {:timeout, {Task, :await, [task, 1000]}})
+    task = ExRPC.async(slave, Kernel, :throw, [:throwSlave])
+    assert {:ok, :throwSlave} === ExRPC.yield(task, 1000)
+    assert nil === ExRPC.yield(task, 1000)
+    assert catch_exit(ExRPC.await(task, 1000) == {:timeout, {Task, :await, [task, 1000]}})
   end
 
   test "Async slave with process exit on remote node" do
-    task = ExRPC.async(slave, :erlang, :apply, [fn() -> exit(:exitslave) end, []])
-    assert :throwslave === ExRPC.await(task, 1000)
+    task = ExRPC.async(slave, Kernel, :exit, [:exitslave])
+    assert {:badrpc, {:EXIT, :exitslave}} === ExRPC.await(task, 1000)
+    task = ExRPC.async(slave, :erlang, :exit, [:exitslave])
+    assert {:badrpc, {:EXIT, :exitslave}} === ExRPC.yield(task)
   end
 
   test "Async with process throw on remote node" do
-    task = ExRPC.async(slave, :erlang, :apply, [fn() -> throw(:throwslave) end, []])
-    assert :throwslave === ExRPC.await(task, 1000)
+    task = ExRPC.async(slave, :erlang, :throw, [:throwSlave])
+    assert :throwSlave === ExRPC.await(task, 1000)
+    task = ExRPC.async(slave, Kernel, :throw, [:throwSlave])
+    assert :throwSlave === ExRPC.await(task, 1000)
+  end
+  test "Async with process raise on remote node" do
+    task = ExRPC.async(master, :erlang, :apply, [fn -> raise ArgumentError, :badarg end, []])
+    assert {:badrpc, {:EXIT, {:function_clause, [{ArgumentError, :exception, [:badarg],_},
+_,_,_,_]}}} = (ExRPC.await(task, 1000))
   end
 
   test "Async slave with process timeout on remote node" do
-    task = ExRPC.async(slave, :erlang, :apply, [fn() -> :timer.sleep(10000) end, []])
-    assert {:badrpc, :timeout} === ExRPC.await(task, 1000)
+    task = ExRPC.async(slave, :timer,:sleep, [10000])
+    assert catch_exit(ExRPC.await(task, 1000) == {:timeout, {Task, :await, [task, 1000]}})
   end
 
 end

--- a/test/functional/async_test.exs
+++ b/test/functional/async_test.exs
@@ -17,51 +17,74 @@ defmodule ExRPC.Test.Functional.Async do
   end
 
   test "Async" do
-    assert true = ExRPC.cast(slave, :os, :timestamp, [])
+    task = ExRPC.async(slave, :os, :timestamp, [])
+    assert {_,_,_} =  ExRPC.await(task, 1000) 
+    task = ExRPC.async(slave, :os, :timestamp, [])
+    assert {_,_,_} =  ExRPC.await(task) 
+    task = ExRPC.async(slave, :os, :timestamp, [])
+    assert {_,_,_} =  ExRPC.yield(task, 1000)
+    task = ExRPC.async(slave, :os, :timestamp, [])
+    assert {_,_,_} =  ExRPC.yield(task) 
   end
 
   test "Async on local node mf" do
-    assert true= ExRPC.cast(master, :erlang, :node)
+    task = ExRPC.async(master, :erlang, :node)
+    assert master ===  ExRPC.await(task, 1000)
+
   end
 
   test "Async on local node mfa" do
-    assert true = ExRPC.cast(master, Kernel, :send, [self, {:test, 'wawasing'}])
+    task = ExRPC.async(master, Kernel, :send, [self, {:test, 'wawasing'}])
     receive do
         {:test, _} -> true
         msg ->  :erlang.error RuntimeError.exception(msg) 
     end
+     assert master ===  ExRPC.await(task, 1000)   
+
   end
 
   test "Async with invalid function" do
-    assert true = ExRPC.cast(slave, :os, :timestamp_undef, [])
+    task = ExRPC.async(slave, :os, :timestamp_undef, [])
+    assert {:badrpc,  _} = ExRPC.await(task, 1000)
   end
 
   test "Async on invalid node" do
-    assert true = ExRPC.cast(invalid, :os, :timestamp, [])
+    task =  ExRPC.async(invalid, :os, :timestamp, [])
+    assert {:badrpc, :nodedown} === ExRPC.await(task, 1000)
   end
 
-  test "Async with process exit" do
-    assert true = ExRPC.cast(slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+  test "Async with process exit on local node" do
+    task =  ExRPC.async(master, :erlang, :apply, [fn() -> exit(:die) end, []])
+    assert :die === ExRPC.await(task, 1000)
   end
 
-  test "Async local with process throw" do
-    assert true =
-      ExRPC.cast(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  test "Async with process throw on local node" do
+    task = ExRPC.async(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+    assert :throwmaster === ExRPC.await(task, 1000)
   end
 
-  test "Async slave with process exit" do
-    assert true  =
-      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+  test "Async slave with process timeout on local node" do
+    task = ExRPC.async(slave, :erlang, :apply, [fn() -> :timer.sleep(10000) end, []])
+    assert {:badrpc, :timeout} === ExRPC.await(task, 1000)
   end
 
   test "Await cannot reuse reference" do
-    assert true  =
-      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+    task = ExRPC.async(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
   end
 
-  test "Async slave with process exit" do
-    assert true  =
-      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+  test "Async slave with process exit on remote node" do
+    task = ExRPC.async(slave, :erlang, :apply, [fn() -> exit(:exitslave) end, []])
+    assert :throwslave === ExRPC.await(task, 1000)
+  end
+
+  test "Async with process throw on remote node" do
+    task = ExRPC.async(slave, :erlang, :apply, [fn() -> throw(:throwslave) end, []])
+    assert :throwslave === ExRPC.await(task, 1000)
+  end
+
+  test "Async slave with process timeout on remote node" do
+    task = ExRPC.async(slave, :erlang, :apply, [fn() -> :timer.sleep(10000) end, []])
+    assert {:badrpc, :timeout} === ExRPC.await(task, 1000)
   end
 
 end

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -1,9 +1,7 @@
 defmodule ExRPC.Test.Functional.Call do
   use ExUnit.Case
-
-  @master :'exrpc@127.0.0.1'
-  @slave :'exrpc_slave@127.0.0.1'
-  @invalid :'exrpc_invalid@127.0.0.1'
+  
+  import ExRPC.Test.Helper
 
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
@@ -13,36 +11,50 @@ defmodule ExRPC.Test.Functional.Call do
     :ok
   end
 
+  test "Call on local node" do
+    assert {_mega, _sec, _micro} = ExRPC.call(invalid, :os, :timestamp, [])
+  end
+
   test "Call on invalid node" do
-    assert {:badrpc, :nodedown} = ExRPC.call(@invalid, :os, :timestamp, [])
+    assert {:badrpc, :nodedown} = ExRPC.call(invalid, :os, :timestamp, [])
   end
 
   test "Call with valid eponymous function" do
-    assert {_mega, _sec, _micro} = ExRPC.call(@slave, :os, :timestamp, [], 1000)
+    assert {_mega, _sec, _micro} = ExRPC.call(slave, :os, :timestamp, [], 1000)
   end
 
   test "Call with invalid eponymous function" do
     assert {:badrpc, {:'EXIT', {:undef, [{:os,:timestamp_undef, [], []}|_]}}} =
-      ExRPC.call(@slave, :os, :timestamp_undef, [])
+      ExRPC.call(slave, :os, :timestamp_undef, [])
   end
 
   test "Call with valid anonymous function" do
     assert {_,"call_anonymous_function"} =
-      ExRPC.call(@master, :erlang, :apply, [fn(a) -> {self(), a} end, ["call_anonymous_function"]])
+      ExRPC.call(master, :erlang, :apply, [fn(a) -> {self(), a} end, ["call_anonymous_function"]])
   end
 
   test "Call with invalid anonymous function" do
     assert {:badrpc, {:'EXIT', {:undef, [{:erlang,:apply, _, _}|_]}}} =
-      ExRPC.call(@master, :erlang, :apply, [fn() -> :os.timestamp_undef() end])
+      ExRPC.call(master, :erlang, :apply, [fn() -> :os.timestamp_undef() end])
   end
 
   test "Call with process exit" do
     assert {:badrpc, {:'EXIT', :die}} =
-      ExRPC.call(@master, :erlang, :apply, [fn() -> exit(:die) end, []])
+      ExRPC.call(master, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+  test "Call local with process throw" do
+    assert :throwMaster =
+      ExRPC.call(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  end
+
+  test "Call slave with process exit" do
+    assert :throwSlave =
+      ExRPC.call(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
   end
 
   test "Call with call timeout" do
-    assert {:badrpc, :timeout} = ExRPC.call(@slave, :timer, :sleep, [100], 1)
+    assert {:badrpc, :timeout} = ExRPC.call(slave, :timer, :sleep, [100], 1)
     # Wait for the remote process to die
     :timer.sleep(100)
   end

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -16,13 +16,12 @@ defmodule ExRPC.Test.Functional.Call do
   end
 
   test "Call on local node mf" do
-    assert ExRPC.Test.Helper.master = ExRPC.call(master, :erlang, :node, [])
+    assert ExRPC.Test.Helper.master = ExRPC.call(master, :erlang, :node)
   end
 
   test "Call on local node mfa" do
     assert [3,2,1] = ExRPC.call(master, :erlang, :apply, [Enum, :reverse, [[1, 2, 3]]])
   end
-
 
   test "Call on invalid node" do
     assert {:badrpc, :nodedown} = ExRPC.call(invalid, :os, :timestamp, [])

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -15,6 +15,15 @@ defmodule ExRPC.Test.Functional.Call do
     assert {_mega, _sec, _micro} = ExRPC.call(master, :os, :timestamp, [])
   end
 
+  test "Call on local node mf" do
+    assert ExRPC.Test.Helper.master = ExRPC.call(master, :erlang, :node, [])
+  end
+
+  test "Call on local node mfa" do
+    assert [3,2,1] = ExRPC.call(master, :erlang, :apply, [Enum, :reverse, [[1, 2, 3]]])
+  end
+
+
   test "Call on invalid node" do
     assert {:badrpc, :nodedown} = ExRPC.call(invalid, :os, :timestamp, [])
   end

--- a/test/functional/call_test.exs
+++ b/test/functional/call_test.exs
@@ -12,7 +12,7 @@ defmodule ExRPC.Test.Functional.Call do
   end
 
   test "Call on local node" do
-    assert {_mega, _sec, _micro} = ExRPC.call(invalid, :os, :timestamp, [])
+    assert {_mega, _sec, _micro} = ExRPC.call(master, :os, :timestamp, [])
   end
 
   test "Call on invalid node" do
@@ -46,11 +46,6 @@ defmodule ExRPC.Test.Functional.Call do
   test "Call local with process throw" do
     assert :throwMaster =
       ExRPC.call(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
-  end
-
-  test "Call slave with process exit" do
-    assert :throwSlave =
-      ExRPC.call(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
   end
 
   test "Call with call timeout" do

--- a/test/functional/cast_test.exs
+++ b/test/functional/cast_test.exs
@@ -15,6 +15,18 @@ defmodule ExRPC.Test.Functional.Cast do
     assert true = ExRPC.cast(slave, :os, :timestamp, [])
   end
 
+  test "Cast on local node mf" do
+    assert true= ExRPC.cast(master, :erlang, :node)
+  end
+
+  test "Cast on local node mfa" do
+    assert true = ExRPC.cast(master, Kernel, :send, [self, {:test, 'wawasing'}])
+    receive do
+        {:test, _} -> true
+        msg ->  :erlang.error RuntimeError.exception(msg) 
+    end
+  end
+
   test "Cast with invalid function" do
     assert true = ExRPC.cast(slave, :os, :timestamp_undef, [])
   end

--- a/test/functional/cast_test.exs
+++ b/test/functional/cast_test.exs
@@ -1,8 +1,7 @@
 defmodule ExRPC.Test.Functional.Cast do
   use ExUnit.Case
 
-  @slave :'exrpc_slave@127.0.0.1'
-  @invalid :'exrpc_invalid@127.0.0.1'
+  import ExRPC.Test.Helper
 
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
@@ -13,19 +12,29 @@ defmodule ExRPC.Test.Functional.Cast do
   end
 
   test "Cast" do
-    assert true = ExRPC.cast(@slave, :os, :timestamp, [])
+    assert true = ExRPC.cast(slave, :os, :timestamp, [])
   end
 
   test "Cast with invalid function" do
-    assert true = ExRPC.cast(@slave, :os, :timestamp_undef, [])
+    assert true = ExRPC.cast(slave, :os, :timestamp_undef, [])
   end
 
   test "Cast on invalid node" do
-    assert true = ExRPC.cast(@invalid, :os, :timestamp, [])
+    assert true = ExRPC.cast(invalid, :os, :timestamp, [])
   end
 
   test "Cast with process exit" do
-    assert true = ExRPC.cast(@slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+    assert true = ExRPC.cast(slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+  end
+
+  test "Call local with process throw" do
+    assert true =
+      ExRPC.cast(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  end
+
+  test "Call slave with process exit" do
+    assert true  =
+      ExRPC.cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
   end
 
 end

--- a/test/functional/safe_cast_test.exs
+++ b/test/functional/safe_cast_test.exs
@@ -1,8 +1,7 @@
 defmodule ExRPC.Test.Functional.SafeCast do
   use ExUnit.Case
 
-  @slave :'exrpc_slave@127.0.0.1'
-  @invalid :'exrpc_invalid@127.0.0.1'
+  import ExRPC.Test.Helper
 
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
@@ -13,19 +12,31 @@ defmodule ExRPC.Test.Functional.SafeCast do
   end
 
   test "Safe cast with invalid function" do
-    assert true = ExRPC.safe_cast(@slave, :os, :timestamp_undef, [])
+    assert true = ExRPC.safe_cast(slave, :os, :timestamp_undef, [])
   end
 
   test "Safe cast with invalid node" do
-    assert {:badrpc, :nodedown} = ExRPC.safe_cast(@invalid, :os, :timestamp, [])
+    assert {:badrpc, :nodedown} = ExRPC.safe_cast(invalid, :os, :timestamp, [])
   end
 
   test "Safe cast with process exit" do
-    assert true = ExRPC.safe_cast(@slave, :erlang, :apply, [fn() -> exit(:die) end, []])
+    assert true = ExRPC.safe_cast(slave, :erlang, :apply, [fn() -> exit(:die) end, []])
   end
 
   test "Call to slave node" do
-    assert {_mega, _sec, _micro} = ExRPC.call(@slave, :os, :timestamp, [], 1000)
+    assert true = ExRPC.safe_cast(slave, :os, :timestamp, [], 1000)
   end
+
+
+  test "Call local with process throw" do
+    assert true =
+      ExRPC.safe_cast(master, :erlang, :apply, [fn() -> throw(:throwMaster) end, []])
+  end
+
+  test "Call slave with process exit" do
+    assert true  =
+      ExRPC.safe_cast(slave, :erlang, :apply, [fn() -> throw(:throwSlave) end, []])
+  end
+
 
 end

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -9,7 +9,6 @@ defmodule ExRPC.Test.Moduledoc do
     :ok
   end
 
-
   doctest ExRPC
 
 end

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -1,8 +1,6 @@
 defmodule ExRPC.Test.Moduledoc do
   use ExUnit.Case
 
-  import ExRPC.Test.Helper
-
   setup_all do
     ExRPC.Test.Helper.start_slave_node()
     on_exit fn() ->

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -2,7 +2,7 @@ defmodule ExRPC.Test.Moduledoc do
   use ExUnit.Case
 
   setup_all do
-    ExRPC.Test.Helper.start_slave_node()
+    {:ok, _} = ExRPC.Test.Helper.start_slave_node()
     on_exit fn() ->
       ExRPC.Test.Helper.stop_slave_node()
     end

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -1,5 +1,5 @@
 defmodule ExRPC.Test.Moduledoc do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   setup_all do
     {:ok, _} = ExRPC.Test.Helper.start_slave_node()

--- a/test/moduledoc_test.exs
+++ b/test/moduledoc_test.exs
@@ -1,6 +1,17 @@
 defmodule ExRPC.Test.Moduledoc do
   use ExUnit.Case
 
+  import ExRPC.Test.Helper
+
+  setup_all do
+    ExRPC.Test.Helper.start_slave_node()
+    on_exit fn() ->
+      ExRPC.Test.Helper.stop_slave_node()
+    end
+    :ok
+  end
+
+
   doctest ExRPC
 
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,16 +1,19 @@
 defmodule ExRPC.Test.Helper do
 
-  @master :'exrpc@127.0.0.1'
-  @slave :'exrpc_slave@127.0.0.1'
-  @slave_ip :'127.0.0.1'
-  @slave_name :'exrpc_slave'
+  defmacro master do :'exrpc@127.0.0.1' end
+  defmacro slave do :'exrpc_slave@127.0.0.1' end
+  defmacro slave1 do :'exrpc_slave1@127.0.0.1' end
+  defmacro slave2 do :'exrpc_slave2@127.0.0.1' end
+  defmacro slave_ip do :'127.0.0.1' end
+  defmacro slave_name do :'exrpc_slave' end
+  defmacro invalid do :'exrpc_invalid@127.0.0.1' end
 
   def start_master_node() do
-    case :net_kernel.start([{:longnames, true}, @master]) do
+    case :net_kernel.start([{:longnames, true}, master]) do
       {:ok, _} ->
-        {:ok, {@master, :started}};
+        {:ok, {master, :started}};
       {:error,{:already_started, _pid}} ->
-        {:ok, {@master, :already_started}};
+        {:ok, {master, :already_started}};
       {:error, reason} ->
         {:error, reason}
     end
@@ -20,13 +23,13 @@ defmodule ExRPC.Test.Helper do
   def start_slave_node() do
     cookie = :erlang.get_cookie |> Atom.to_char_list
     erl_flags = ' -kernel dist_auto_connect once +K true -setcookie ' ++ cookie
-    {:ok, _slave} = :slave.start(@slave_ip, @slave_name, erl_flags)
-    :ok = :rpc.call(@slave, :code, :add_pathsz, [:code.get_path()])
-    {:ok, _slave_apps} = :rpc.call(@slave, Application, :ensure_all_started, [:exrpc])
+    {:ok, _slave} = :slave.start(slave_ip, slave_name, erl_flags)
+    :ok = :rpc.call(slave, :code, :add_pathsz, [:code.get_path()])
+    {:ok, _slave_apps} = :rpc.call(slave, Application, :ensure_all_started, [:exrpc])
   end
 
   def stop_slave_node() do
-    :ok = :slave.stop(@slave)
+    :ok = :slave.stop(slave)
   end
 
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -40,6 +40,21 @@ defmodule ExRPC.Test.Helper do
     :ok = :slave.stop(node_name)
   end
 
+  def spawn_long_running(time_span) do
+    :proc_lib.spawn_link(:timer, :sleep, [time_span])
+  end
+
+  def spawn_short_running() do
+    :proc_lib.spawn_link(:erlang,:exit, [:normal])
+  end
+
+  # 
+  def wait_and_send(caller, message) do
+    send caller, :ready
+    receive do: (true -> true)
+    send caller, message
+  end
+
 end
 
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -21,15 +21,23 @@ defmodule ExRPC.Test.Helper do
   end
 
   def start_slave_node() do
+    start_slave_node(slave_name, slave)
+  end
+
+  def start_slave_node(node_name, node_full_name) do
     cookie = :erlang.get_cookie |> Atom.to_char_list
     erl_flags = ' -kernel dist_auto_connect once +K true -setcookie ' ++ cookie
-    {:ok, _slave} = :slave.start(slave_ip, slave_name, erl_flags)
+    {:ok, _slave} = :slave.start(slave_ip, node_name, erl_flags)
     :ok = :rpc.call(slave, :code, :add_pathsz, [:code.get_path()])
-    {:ok, _slave_apps} = :rpc.call(slave, Application, :ensure_all_started, [:exrpc])
+    {:ok, _slave_apps} = :rpc.call(node_full_name, Application, :ensure_all_started, [:exrpc])
   end
 
   def stop_slave_node() do
     :ok = :slave.stop(slave)
+  end
+
+  def stop_slave_node(node_name) do
+    :ok = :slave.stop(node_name)
   end
 
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,7 +9,7 @@ defmodule ExRPC.Test.Helper do
   defmacro invalid do :'exrpc_invalid@127.0.0.1' end
 
   def start_master_node() do
-    case :net_kernel.start([{:longnames, true}, master]) do
+    case Node.start(master, :longnames) do
       {:ok, _} ->
         {:ok, {master, :started}};
       {:error,{:already_started, _pid}} ->


### PR DESCRIPTION
- implemented async, yield, await 
- fixes some syntax error in other parts of library
- unit tests
- Elixir.Task their better version of rpc, remote spawn etc and is part of their standard lib.
- so semantics is closer to Elxir.Task rather than erlang:rpc
- for example, they use concepts of exception in addition to erlang tuple etc. This can be confusing.
- raise is a macro but throw is a function (because of erlang counterpart). raise causes undef error on :erlang, apply because of being a macro.
  NB; this project is my mayden Elixir voyage
